### PR TITLE
Added code to make the description property optional. 

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -149,8 +149,12 @@ var Generator = (function () {
                     return;
                 }
                 
-                var summaryLines = op.description.split('\n');
-                summaryLines.splice(summaryLines.length-1, 1);
+                // The description line is optional in the spec
+                var summaryLines = [];
+                if (op.description) {
+                    summaryLines = op.description.split('\n');
+                    summaryLines.splice(summaryLines.length-1, 1);
+                }
                 
                 
                 


### PR DESCRIPTION
I had a Swagger spec which I was given that didn't have a description on one of the end points. It took me awhile to find the problem end point and I got it fixed so it has a description but then I checked the Swagger 2.0 spec and it wasn't required, so I made this minor change so it doesn't crash next time I run this for a Swagger doc where the guys don't add a description.

Thanks for your work on this. I look forward to seeing how this works with my Angular2 app.
