### PR TITLE
Added a camelize function for poorly written operationIds

### DIFF
--- a/src/generator.js
+++ b/src/generator.js
@@ -138,7 +138,7 @@ var Generator = (function () {
         // Simple function to camelize poorly written operationId's.
         var camelize = function (string) { 
             string = string.replace (/(?:^|(\W|_)+)(\w)/g, function (match, p1, p2) {
-                return c ? c.toUpperCase () : '';
+                return p2 ? p2.toUpperCase () : '';
             });
 
             return string.charAt(0).toLowerCase() + string.slice(1);

--- a/src/generator.js
+++ b/src/generator.js
@@ -134,6 +134,15 @@ var Generator = (function () {
             methods: [],
             definitions: []
         };
+        
+        // Simple function to camelize poorly written operationId's.
+        var camelize = function (string) { 
+            string = string.replace (/(?:^|(\W|_)+)(\w)/g, function (match, p1, p2) {
+                return c ? c.toUpperCase () : '';
+            });
+
+            return string.charAt(0).toLowerCase() + string.slice(1);
+        }
 
         _.forEach(swagger.paths, function (api, path) {
             var globalParams = [];
@@ -161,7 +170,7 @@ var Generator = (function () {
                 var method = {
                     path: path,
                     backTickPath: path.replace(/(\{.*?\})/g, "$$$1"),
-                    methodName: op['x-swagger-js-method-name'] ? op['x-swagger-js-method-name'] : (op.operationId ? op.operationId : that.getPathToMethodName(m, path)),
+                    methodName: op['x-swagger-js-method-name'] ? op['x-swagger-js-method-name'] : (op.operationId ? camelize(op.operationId) : that.getPathToMethodName(m, path)),
                     method: m.toUpperCase(),
                     angular2httpMethod: m.toLowerCase(),
                     isGET: m.toUpperCase() === 'GET',


### PR DESCRIPTION
We are using Loopback for our server and it generates some operationIds like `User.prototype.__create__accessTokens` in the swagger doc it produces. As you can imaging using that as a name for a public method doesn't work :)

There is a [issue](https://github.com/strongloop/loopback/issues/2041) in Loopback and it looks like they are working on it but not sure of a timeline.

I am open to any suggestions on my implementation. I just created a camelize function which does some regex to convert it to a camel-case format.
