### PR TITLE
Auto creation of interface for api client

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,21 @@ a2apigen -u [url/of/your/swagger.json] -c [className] -g [GenerateParameter]
 ```
 
 If parameter -c is not provided, class name will be ApiClient Service.
+
 Available values for parameter -g are I, M, C or F, as well as you can combine them.  
 
 ## Parameters
 
 Options:
+
   -s, --source      Path to your swagger.json file
+
   -u, --url         Url of your swagger.json file
+
   -o, --outputpath  Path where to store generated files
+
   -c, --className   Class name for Api client
+
   -g, --generate    What to generate, F for full (default), I for interfaces, M for models, C for classes
 
 ## Example usage:

--- a/README.md
+++ b/README.md
@@ -21,13 +21,15 @@ or
 
 From commandline run:
 ```
-a2apigen -s [yopur/path/to/swagger.json]
+a2apigen -s [yopur/path/to/swagger.json] -c [className]
 ```
 
 or
 ```
-a2apigen -u [url/of/your/swagger.json]
+a2apigen -u [url/of/your/swagger.json] -c [className]
 ```
+
+If parameter -c is not provided, class name will be ApiClient Service.
 
 ## Example usage:
 

--- a/README.md
+++ b/README.md
@@ -21,15 +21,16 @@ or
 
 From commandline run:
 ```
-a2apigen -s [your/path/to/swagger.json] -c [className]
+a2apigen -s [your/path/to/swagger.json] -c [className] -g [GenerateParameter]
 ```
 
 or
 ```
-a2apigen -u [url/of/your/swagger.json] -c [className]
+a2apigen -u [url/of/your/swagger.json] -c [className] -g [GenerateParameter]
 ```
 
 If parameter -c is not provided, class name will be ApiClient Service.
+Available values for parameter -g are I, M, C or F, as well as you can combine them.  
 
 ## Parameters
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ or
 
 From commandline run:
 ```
-a2apigen -s [yopur/path/to/swagger.json] -c [className]
+a2apigen -s [your/path/to/swagger.json] -c [className]
 ```
 
 or
@@ -30,6 +30,15 @@ a2apigen -u [url/of/your/swagger.json] -c [className]
 ```
 
 If parameter -c is not provided, class name will be ApiClient Service.
+
+## Parameters
+
+Options:
+  -s, --source      Path to your swagger.json file
+  -u, --url         Url of your swagger.json file
+  -o, --outputpath  Path where to store generated files
+  -c, --className   Class name for Api client
+  -g, --generate    What to generate, F for full (default), I for interfaces, M for models, C for classes
 
 ## Example usage:
 

--- a/src/a2apigen.js
+++ b/src/a2apigen.js
@@ -20,7 +20,7 @@ var optimist = require('optimist')
     .describe('u', 'Url of your swagger.json file')
     .describe('o', 'Path where to store generated files')
     .describe('c', 'Class name for Api client')
-    .describe('g', 'What to generate, F for full (default), I for interfaces, M for models')
+    .describe('g', 'What to generate, F for full (default), I for interfaces, M for models and C for classes')
     
 var fs = require('fs');
 
@@ -62,6 +62,8 @@ var sourceFile = argv.source;
 
 var className = argv.className || 'ApiClientService';
 
+var generate = argv.generate || 'F';
+
 if (fromUrl) {
     var request = require('request');
     var path = require('path');
@@ -78,14 +80,14 @@ if (fromUrl) {
 
             fs.writeFileSync(dest, body, 'utf-8');
 
-            var g = new genRef.Generator(dest, outputdir, className);
+            var g = new genRef.Generator(dest, outputdir, className, generate);
             g.Debug = true;
             g.generateAPIClient();
         });
 }
 else {
     //Do Job
-    var g = new genRef.Generator(sourceFile, outputdir, className);
+    var g = new genRef.Generator(sourceFile, outputdir, className, generate);
     g.Debug = true;
     g.generateAPIClient();
 }

--- a/src/a2apigen.js
+++ b/src/a2apigen.js
@@ -15,13 +15,15 @@ var optimist = require('optimist')
     .alias('u', 'url')
     .alias('o', 'outputpath')
     .alias('c', 'className')
-    .alias ('g', 'generate')
+    .alias('g', 'generate')
+    .alias('m', 'modelInterfaces')
     .describe('s', 'Path to your swagger.json file')
     .describe('u', 'Url of your swagger.json file')
     .describe('o', 'Path where to store generated files')
     .describe('c', 'Class name for Api client')
     .describe('g', 'What to generate, F for full (default), I for interfaces, M for models and C for classes')
-    
+    .describe('m', 'Path where model interfaces are stored')
+
 var fs = require('fs');
 
 var genRef = require('../lib/generator');
@@ -64,6 +66,8 @@ var className = argv.className || 'ApiClientService';
 
 var generate = argv.generate || 'F';
 
+var modelInterfaces = argv.modelInterfaces || null;
+
 if (fromUrl) {
     var request = require('request');
     var path = require('path');
@@ -80,14 +84,14 @@ if (fromUrl) {
 
             fs.writeFileSync(dest, body, 'utf-8');
 
-            var g = new genRef.Generator(dest, outputdir, className, generate);
+            var g = new genRef.Generator(dest, outputdir, className, generate, modelInterfaces);
             g.Debug = true;
             g.generateAPIClient();
         });
 }
 else {
     //Do Job
-    var g = new genRef.Generator(sourceFile, outputdir, className, generate);
+    var g = new genRef.Generator(sourceFile, outputdir, className, generate, modelInterfaces);
     g.Debug = true;
     g.generateAPIClient();
 }

--- a/src/a2apigen.js
+++ b/src/a2apigen.js
@@ -14,10 +14,14 @@ var optimist = require('optimist')
     .alias('s', 'source')
     .alias('u', 'url')
     .alias('o', 'outputpath')
+    .alias('c', 'className')
+    .alias ('g', 'generate')
     .describe('s', 'Path to your swagger.json file')
     .describe('u', 'Url of your swagger.json file')
-    .describe('o', 'Path where to store generated files');
-
+    .describe('o', 'Path where to store generated files')
+    .describe('c', 'Class name for Api client')
+    .describe('g', 'What to generate, F for full (default), I for interfaces, M for models')
+    
 var fs = require('fs');
 
 var genRef = require('../lib/generator');

--- a/src/a2apigen.js
+++ b/src/a2apigen.js
@@ -60,6 +60,8 @@ if (!fs.existsSync(outputdir))
 
 var sourceFile = argv.source;
 
+var className = argv.className || 'ApiClientService';
+
 if (fromUrl) {
     var request = require('request');
     var path = require('path');
@@ -76,14 +78,14 @@ if (fromUrl) {
 
             fs.writeFileSync(dest, body, 'utf-8');
 
-            var g = new genRef.Generator(dest, outputdir);
+            var g = new genRef.Generator(dest, outputdir, className);
             g.Debug = true;
             g.generateAPIClient();
         });
 }
 else {
     //Do Job
-    var g = new genRef.Generator(sourceFile, outputdir);
+    var g = new genRef.Generator(sourceFile, outputdir, className);
     g.Debug = true;
     g.generateAPIClient();
 }

--- a/src/generator.js
+++ b/src/generator.js
@@ -8,11 +8,12 @@ var _ = require('lodash');
 
 var Generator = (function () {
 
-    function Generator(swaggerfile, outputpath, className, generate) {
+    function Generator(swaggerfile, outputpath, className, generate, modelInterfaces) {
         this._className = className;
         this._swaggerfile = swaggerfile;
         this._outputPath = outputpath;
         this._generate = generate;
+        this._modelInterfaces = modelInterfaces;
     }
 
     Generator.prototype.Debug = false;

--- a/src/generator.js
+++ b/src/generator.js
@@ -8,10 +8,11 @@ var _ = require('lodash');
 
 var Generator = (function () {
 
-    function Generator(swaggerfile, outputpath, className) {
+    function Generator(swaggerfile, outputpath, className, generate) {
         this._className = className;
         this._swaggerfile = swaggerfile;
         this._outputPath = outputpath;
+        this._generate = generate;
     }
 
     Generator.prototype.Debug = false;
@@ -42,11 +43,29 @@ var Generator = (function () {
         if (this.initialized !== true)
             this.initialize();
 
-        this.generateInterface();
-        this.generateClient();
-        this.generateModels();
-        this.generateCommonModelsExportDefinition();
+        for (var i = 0; i < this._generate.length; i++) {
+            var param = this._generate[i];
+            this.LogMessage("Generate file: " + param);
 
+            if (param == 'F') {
+                this.LogMessage("Generating full package.");                        
+                this.generateInterface();
+                this.generateClient();
+                this.generateModels();
+                this.generateCommonModelsExportDefinition();
+            }
+            else if (param == 'M') {
+                this.generateModels();
+                this.generateCommonModelsExportDefinition();
+            }
+            else if (param == 'I') {
+                this.generateInterface();
+            }
+            else if (param == 'C') {
+                this.generateClient();
+            }
+        }
+        
         this.LogMessage('API client generated successfully');
     };
 

--- a/src/generator.js
+++ b/src/generator.js
@@ -57,7 +57,7 @@ var Generator = (function () {
         this.LogMessage('Rendering interface template for API');
         var result = this.renderLintAndBeautify(this.templates.interface, this.viewModel, this.templates);
 
-        var outfile = this._outputPath + "/" + "index.ts";
+        var outfile = this._outputPath + "/" + "index.interface.ts";
         this.LogMessage('Creating output file for interface', outfile);
         fs.writeFileSync(outfile, result, 'utf-8')
     };

--- a/src/generator.js
+++ b/src/generator.js
@@ -8,7 +8,8 @@ var _ = require('lodash');
 
 var Generator = (function () {
 
-    function Generator(swaggerfile, outputpath) {
+    function Generator(swaggerfile, outputpath, className) {
+        this._className = className;
         this._swaggerfile = swaggerfile;
         this._outputPath = outputpath;
     }

--- a/src/generator.js
+++ b/src/generator.js
@@ -25,6 +25,7 @@ var Generator = (function () {
         this.LogMessage('Reading Mustache templates');
 
         this.templates = {
+            'interface': fs.readFileSync(__dirname + "/../templates/angular2-service.interface.mustache", 'utf-8'),
             'class': fs.readFileSync(__dirname + "/../templates/angular2-service.mustache", 'utf-8'),
             'model': fs.readFileSync(__dirname + "/../templates/angular2-model.mustache", 'utf-8'),
             'models_export': fs.readFileSync(__dirname + "/../templates/angular2-models-export.mustache", 'utf-8')
@@ -40,11 +41,25 @@ var Generator = (function () {
         if (this.initialized !== true)
             this.initialize();
 
+        this.generateInterface();
         this.generateClient();
         this.generateModels();
         this.generateCommonModelsExportDefinition();
 
         this.LogMessage('API client generated successfully');
+    };
+
+    Generator.prototype.generateInterface = function () {
+        if (this.initialized !== true)
+            this.initialize();
+
+        // generate main API client interface
+        this.LogMessage('Rendering interface template for API');
+        var result = this.renderLintAndBeautify(this.templates.interface, this.viewModel, this.templates);
+
+        var outfile = this._outputPath + "/" + "index.ts";
+        this.LogMessage('Creating output file for interface', outfile);
+        fs.writeFileSync(outfile, result, 'utf-8')
     };
 
     Generator.prototype.generateClient = function () {

--- a/src/generator.js
+++ b/src/generator.js
@@ -142,6 +142,8 @@ var Generator = (function () {
         var swagger = this.swaggerParsed;
         var authorizedMethods = ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'];
         var data = {
+            className: this._className,
+            interfaceName: "I" + this._className,
             isNode: false,
             description: (swagger.info && swagger.info.description) ? swagger.info.description : '',
             isSecure: swagger.securityDefinitions !== undefined,

--- a/templates/angular2-service.interface.mustache
+++ b/templates/angular2-service.interface.mustache
@@ -1,0 +1,26 @@
+/* tslint:disable */
+import { {{#definitions}}{{name}}{{^last}}, {{/last}}{{/definitions}} } from './models';
+import { Observable } from 'rxjs';
+
+/**
+ * Created with angular2-swagger-client-generator v{{&version}}
+ */
+interface IApiClientService {
+{{#methods}}
+	/**
+  * {{{summary}}}
+	{{#summaryLines}}
+  * {{&.}}
+  {{/summaryLines}}
+  *
+	* @method
+	* @name {{&methodName}}
+	{{#parameters}}
+	{{^isSingleton}}* @param {{=<% %>=}}{<%&type%>}<%={{ }}=%> {{&camelCaseName}} - {{&description}}{{/isSingleton}}
+	{{/parameters}}
+	*/
+	{{&methodName}}({{#parameters}}{{&camelCaseName}}: {{typescriptType}}{{^last}}, {{/last}}{{/parameters}}){{#returns}}: Observable<{{returns}}>{{/returns}};
+
+{{/methods}}
+
+}

--- a/templates/angular2-service.interface.mustache
+++ b/templates/angular2-service.interface.mustache
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs';
 /**
  * Created with angular2-swagger-client-generator v{{&version}}
  */
-interface IApiClientService {
+export interface IApiClientService {
 {{#methods}}
 	/**
   * {{{summary}}}

--- a/templates/angular2-service.interface.mustache
+++ b/templates/angular2-service.interface.mustache
@@ -5,7 +5,7 @@ import { Observable } from 'rxjs';
 /**
  * Created with angular2-swagger-client-generator v{{&version}}
  */
-export interface IApiClientService {
+export interface {{interfaceName}} {
 {{#methods}}
 	/**
   * {{{summary}}}

--- a/templates/angular2-service.mustache
+++ b/templates/angular2-service.mustache
@@ -9,7 +9,7 @@ import { Observable } from 'rxjs';
 /**
  * Created with angular2-swagger-client-generator v{{&version}}
  */
-export class ApiClientService {
+export class ApiClientService implements IApiClientService {
 	domain:string;
 
   constructor(public http: Http){

--- a/templates/angular2-service.mustache
+++ b/templates/angular2-service.mustache
@@ -3,13 +3,13 @@ import { Injectable } from '@angular/core';
 import { Http, Response, RequestOptions, URLSearchParams, Headers } from '@angular/http';
 import { {{#definitions}}{{name}}{{^last}}, {{/last}}{{/definitions}} } from './models';
 import { Observable } from 'rxjs';
-
+import { {{interfaceName }}} from './index.interface';
 
 @Injectable()
 /**
  * Created with angular2-swagger-client-generator v{{&version}}
  */
-export class ApiClientService implements IApiClientService {
+export class {{className}} implements {{interfaceName}} {
 	domain:string;
 
   constructor(public http: Http){


### PR DESCRIPTION
In some cases the complexity of an API Client is higher and therefore the auto generated class may not be used, but an interface is very useful to still support the flexibility of own api client implementations, but still secure quality by at least implementing an interface.